### PR TITLE
Fix credit container ID

### DIFF
--- a/src/pages/docs/styles.astro
+++ b/src/pages/docs/styles.astro
@@ -171,7 +171,7 @@ li.block div:hover {
 
 	<Code
 		lang="css"
-		code={`#credit-container {
+		code={`#creditContainer {
 	display: none;
 }`}
 	/>


### PR DESCRIPTION
The style snippet to hide the Unsplash photo author credits used `#credit-container` instead of `#creditContainer`