### PR TITLE
Fix credit container ID in French docs

### DIFF
--- a/src/pages/fr/docs/styles.astro
+++ b/src/pages/fr/docs/styles.astro
@@ -171,7 +171,7 @@ li.block div:hover {
 
 	<Code
 		lang="css"
-		code={`#credit-container {
+		code={`#creditContainer {
 	display: none;
 }`}
 	/>


### PR DESCRIPTION
The style snippet to hide the Unsplash photo author credits used `#credit-container` instead of `#creditContainer`

This is the same as #16, but in the French docs